### PR TITLE
Bloodlines refactor reducer

### DIFF
--- a/src/actions/bloodlinesActions.js
+++ b/src/actions/bloodlinesActions.js
@@ -1,90 +1,104 @@
-
-export const GET_ALL_CONTENT = "GET_ALL_CONTENT";
-export const HANDLE_GET_ALL_CONTENT = "HANDLE_GET_ALL_CONTENT";
-export const ERROR_GET_ALL_CONTENT = "ERROR_GET_ALL_CONTENT";
-
-export const GET_ALL_TRIGGERS = "GET_ALL_TRIGGERS";
-export const HANDLE_GET_ALL_TRIGGERS = "HANDLE_GET_ALL_TRIGGERS";
-export const ERROR_GET_ALL_TRIGGERS = "ERROR_GET_ALL_TRIGGERS";
+export const HANDLE_PAGED = "HANDLE_PAGED";
+export const ERROR_PAGED = "ERROR_PAGED";
+export const TRIGGERS = "TRIGGERS";
+export const CONTENTS = "CONTENTS";
 
 export const REQUEST = "REQUEST";
 export const HANDLE = "HANDLE";
 export const ERROR = "ERROR";
-
 export const TIMEOUT = "TIMEOUT";
+
 const TIMEOUT_MS = 5000;
 
 const BLOODLINES_URL = "https://bloodlines.expresso.store/api";
 const CONTENT_URL = BLOODLINES_URL + "/content";
 const TRIGGER_URL = BLOODLINES_URL + "/trigger";
 
-function handleGetAllContent(payload, limit, reset) {
-	return {
-		type: HANDLE_GET_ALL_CONTENT,
-		payload,
-		limit,
-		reset
-	};
-}
-function errorGetAllContent(offset, limit, err) {
-	return {
-		type: ERROR_GET_ALL_CONTENT,
-		offset,
-		limit,
-		err
-	};
-}
 export function getAllContent(offset, limit, reset) {
+	return handlePagedRequest(CONTENTS, CONTENT_URL+"?offset="+offset+"&limit="+limit, "GET", offset, limit);
+}
+
+export function getAllTriggers(offset, limit, reset) {
+	return handlePagedRequest(TRIGGERS, TRIGGER_URL+"?offset="+offset+"&limit="+limit, "GET", offset, limit);
+}
+
+export function createContent(body) {
+	return handleRequest(CONTENT_URL, "POST", body);
+}
+
+export function deleteContent(id) {
+	return handleRequest(CONTENT_URL+"/"+id,"DELETE")
+}
+
+export function createTrigger(body) {
+	return handleRequest(TRIGGER_URL, "POST", body);
+}
+
+export function deleteTrigger(id) {
+	return handleRequest(TRIGGER_URL+"/" + id, "DELETE");
+}
+
+function handlePagedRequest(item, url, type, offset, limit) {
 	return dispatch => {
-		return fetch(CONTENT_URL+"?offset="+offset+"&limit="+limit, {
-			method: "GET"
+		return fetch(url, {
+			method: type
 		}).then((res) => {
 			return res.json();
 		}).then((json) => {
 			if (json.error || !json.success) {
-				dispatch(errorGetAllContent(offset, limit, json.message))
+				dispatch(errorPaged(item, offset, limit, json.message));
 				return;
 			}
 
-			dispatch(handleGetAllContent(json, limit, reset))
+			dispatch(handlePaged(item, json, offset, limit))
 		}).catch((err) => {
-			dispatch(errorGetAllContent(offset, limit, err))
+			dispatch(errorPaged(item, offset, limit, err))
 		});
 	}
 }
-function handleGetAllTriggers(payload, limit, reset) {
+
+function handleRequest(url, type, body) {
+	let raw = "";
+	if (body) {
+		raw = JSON.stringify(body);
+	}
+	return dispatch => {
+		setTimeout(() => {
+			dispatch(timeout())
+		}, TIMEOUT_MS);
+		return fetch(url, {
+			method: type,
+			body: raw
+		}).then((res) => {
+			return res.json();
+		}).then((json) => {
+			if (json.error || !json.success) {
+				dispatch(error(body, json.message))
+				return;
+			}
+
+			dispatch(handle(json));
+		}).catch((err) => {
+			dispatch(error(body, err));
+		});
+	}
+}
+
+function handlePaged(itemType, payload, offset, limit) {
 	return {
-		type: HANDLE_GET_ALL_TRIGGERS,
+		type: HANDLE_PAGED,
+		itemType,
 		payload,
-		limit,
-		reset
+		offset,
+		limit
 	};
 }
-function errorGetAllTriggers(offset, limit, err) {
+function errorPaged(itemType, err) {
 	return {
-		type: ERROR_GET_ALL_TRIGGERS,
-		offset,
-		limit,
+		type: ERROR_PAGED,
+		itemType,
 		err
 	};
-}
-export function getAllTriggers(offset, limit, reset) {
-	return dispatch => {
-		return fetch(TRIGGER_URL+"?offset="+offset+"&limit="+limit, {
-			method: "GET"
-		}).then((res) => {
-			return res.json();
-		}).then((json) => {
-			if (json.error || !json.success) {
-				dispatch(errorGetAllTriggers(offset, limit, json.message));
-				return;
-			}
-
-			dispatch(handleGetAllTriggers(json, limit, reset))
-		}).catch((err) => {
-			dispatch(errorGetAllTriggers(offset, limit, err))
-		});
-	}
 }
 function timeout() {
 	return {
@@ -103,92 +117,4 @@ function error(id, err) {
 		id,
 		err
 	};
-}
-
-export function createContent(body) {
-	return dispatch => {
-		setTimeout(() => {
-			dispatch(timeout())
-		}, TIMEOUT_MS);
-		return fetch(CONTENT_URL, {
-			method: "POST",
-			body: JSON.stringify(body)
-		}).then((res) => {
-			return res.json();
-		}).then((json) => {
-			if (json.error || !json.success) {
-				dispatch(error(body, json.message))
-				return;
-			}
-
-			dispatch(handle(json));
-		}).catch((err) => {
-			dispatch(error(body, err));
-		});
-	}
-}
-
-export function deleteContent(id) {
-	return dispatch => {
-		setTimeout(() => {
-			dispatch(timeout())
-		}, TIMEOUT_MS);
-		return fetch(CONTENT_URL+"/"+id, {
-			method: "DELETE"
-		}).then((res) => {
-			return res.json();
-		}).then((json) => {
-			if (json.error || !json.success) {
-				dispatch(error(id, json.message))
-				return;
-			}
-
-			dispatch(handle(json))
-		}).catch((err) => {
-			dispatch(error(id, err))
-		});
-	}
-}
-export function createTrigger(body) {
-	return dispatch => {
-
-		return fetch(TRIGGER_URL, {
-			method: "POST",
-			body: JSON.stringify(body)
-		}).then((res) => {
-			return res.json();
-		}).then((json) => {
-			if (json.error || !json.success) {
-				dispatch(error(body, json.message))
-				return;
-			}
-
-			dispatch(handle(json))
-		}).catch((err) => {
-			dispatch(error(body, err))
-		});
-	}
-}
-
-export function deleteTrigger(id) {
-	return dispatch => {
-		setTimeout(() => {
-			dispatch(timeout());
-		}, TIMEOUT_MS);
-		return fetch(TRIGGER_URL+"/" + id, {
-			method: "DELETE"
-		}).then((res) => {
-			return res.json();
-		}).then((json) => {
-			console.log(json);
-			if (json.error || !json.success) {
-				dispatch(error(id, json.message))
-				return;
-			}
-
-			dispatch(handle(json))
-		}).catch((err) => {
-			dispatch(error(id, err))
-		});
-	}
 }

--- a/src/actions/bloodlinesActions.js
+++ b/src/actions/bloodlinesActions.js
@@ -35,13 +35,6 @@ const BLOODLINES_URL = "https://bloodlines.expresso.store/api";
 const CONTENT_URL = BLOODLINES_URL + "/content";
 const TRIGGER_URL = BLOODLINES_URL + "/trigger";
 
-function sendGetAllContent(offset, limit) {
-	return {
-		type: GET_ALL_CONTENT,
-		offset,
-		limit
-	};
-}
 function handleGetAllContent(payload, limit, reset) {
 	return {
 		type: HANDLE_GET_ALL_CONTENT,
@@ -60,8 +53,6 @@ function errorGetAllContent(offset, limit, err) {
 }
 export function getAllContent(offset, limit, reset) {
 	return dispatch => {
-		dispatch(sendGetAllContent(offset, limit));
-
 		return fetch(CONTENT_URL+"?offset="+offset+"&limit="+limit, {
 			method: "GET"
 		}).then((res) => {
@@ -79,12 +70,6 @@ export function getAllContent(offset, limit, reset) {
 	}
 }
 
-function sendGetContent(id) {
-	return {
-		type: GET_CONTENT,
-		id
-	};
-}
 function handleContent(payload) {
 	return {
 		type: HANDLE_GET_CONTENT,
@@ -99,12 +84,6 @@ function errorGetContent(id, err) {
 	};
 }
 
-function sendCreateContent(content) {
-	return {
-		type: CREATE_CONTENT,
-		content
-	};
-}
 function handleCreateContent(payload) {
 	return {
 		type: HANDLE_CREATE_CONTENT,
@@ -120,8 +99,6 @@ function errorCreateContent(content, err) {
 }
 export function createContent(body) {
 	return dispatch => {
-		dispatch(sendCreateContent(body));
-
 		return fetch(CONTENT_URL, {
 			method: "POST",
 			body: JSON.stringify(body)
@@ -140,12 +117,6 @@ export function createContent(body) {
 	}
 }
 
-function sendDeleteContent(id) {
-	return {
-		type: DELETE_CONTENT,
-		id
-	};
-}
 function handleDeleteContent(payload) {
 	return {
 		type: HANDLE_DELETE_CONTENT,
@@ -161,8 +132,6 @@ function errorDeleteContent(id, err) {
 }
 export function deleteContent(id) {
 	return dispatch => {
-		dispatch(sendDeleteContent(id));
-
 		return fetch(CONTENT_URL+"/"+id, {
 			method: "DELETE"
 		}).then((res) => {
@@ -180,13 +149,6 @@ export function deleteContent(id) {
 	}
 }
 
-function sendGetAllTriggers(offset, limit) {
-	return {
-		type: GET_ALL_TRIGGERS,
-		offset,
-		limit
-	};
-}
 function handleGetAllTriggers(payload, limit, reset) {
 	return {
 		type: HANDLE_GET_ALL_TRIGGERS,
@@ -205,8 +167,6 @@ function errorGetAllTriggers(offset, limit, err) {
 }
 export function getAllTriggers(offset, limit, reset) {
 	return dispatch => {
-		dispatch(sendGetAllTriggers(offset, limit));
-
 		return fetch(TRIGGER_URL+"?offset="+offset+"&limit="+limit, {
 			method: "GET"
 		}).then((res) => {
@@ -224,12 +184,6 @@ export function getAllTriggers(offset, limit, reset) {
 	}
 }
 
-function sendCreateTrigger(body) {
-	return {
-		type: CREATE_TRIGGER,
-		body
-	};
-}
 function handleCreateTrigger(payload) {
 	return {
 		type: HANDLE_CREATE_TRIGGER,
@@ -245,7 +199,6 @@ function errorCreateTrigger(body, err) {
 }
 export function createTrigger(body) {
 	return dispatch => {
-		dispatch(sendCreateTrigger(body));
 
 		return fetch(TRIGGER_URL, {
 			method: "POST",
@@ -265,12 +218,6 @@ export function createTrigger(body) {
 	}
 }
 
-function sendDeleteTrigger(id) {
-	return {
-		type: DELETE_TRIGGER,
-		id
-	};
-}
 function handleDeleteTrigger(payload) {
 	return {
 		type: HANDLE_DELETE_TRIGGER,
@@ -286,8 +233,6 @@ function errorDeleteTrigger(id, err) {
 }
 export function deleteTrigger(id) {
 	return dispatch => {
-		dispatch(errorDeleteTrigger(id));
-
 		return fetch(TRIGGER_URL+"/" + id, {
 			method: "DELETE"
 		}).then((res) => {

--- a/src/actions/bloodlinesActions.js
+++ b/src/actions/bloodlinesActions.js
@@ -3,33 +3,16 @@ export const GET_ALL_CONTENT = "GET_ALL_CONTENT";
 export const HANDLE_GET_ALL_CONTENT = "HANDLE_GET_ALL_CONTENT";
 export const ERROR_GET_ALL_CONTENT = "ERROR_GET_ALL_CONTENT";
 
-export const GET_CONTENT = "GET_CONTENT";
-export const HANDLE_GET_CONTENT = "HANDLE_GET_CONTENT";
-export const ERROR_GET_CONTENT = "ERROR_GET_CONTENT";
-
-export const CREATE_CONTENT = "CREATE_CONTENT";
-export const HANDLE_CREATE_CONTENT = "HANDLE_CREATE_CONTENT";
-export const ERROR_CREATE_CONTENT = "ERROR_CREATE_CONTENT";
-
-export const DELETE_CONTENT = "DELETE_CONTENT";
-export const HANDLE_DELETE_CONTENT = "HANDLE_DELETE_CONTENT";
-export const ERROR_DELETE_CONTENT = "ERROR_DELETE_CONTENT";
-
 export const GET_ALL_TRIGGERS = "GET_ALL_TRIGGERS";
 export const HANDLE_GET_ALL_TRIGGERS = "HANDLE_GET_ALL_TRIGGERS";
 export const ERROR_GET_ALL_TRIGGERS = "ERROR_GET_ALL_TRIGGERS";
 
-export const GET_TRIGGER = "GET_TRIGGER";
-export const HANDLE_GET_TRIGGER = "HANDLE_GET_TRIGGER";
-export const ERROR_GET_TRIGGER = "ERROR_GET_TRIGGER";
+export const REQUEST = "REQUEST";
+export const HANDLE = "HANDLE";
+export const ERROR = "ERROR";
 
-export const CREATE_TRIGGER = "CREATE_TRIGGER";
-export const HANDLE_CREATE_TRIGGER = "HANDLE_CREATE_TRIGGER";
-export const ERROR_CREATE_TRIGGER = "ERROR_CREATE_TRIGGER";
-
-export const DELETE_TRIGGER = "DELETE_TRIGGER";
-export const HANDLE_DELETE_TRIGGER = "HANDLE_DELETE_TRIGGER";
-export const ERROR_DELETE_TRIGGER = "ERROR_DELETE_TRIGGER";
+export const TIMEOUT = "TIMEOUT";
+const TIMEOUT_MS = 5000;
 
 const BLOODLINES_URL = "https://bloodlines.expresso.store/api";
 const CONTENT_URL = BLOODLINES_URL + "/content";
@@ -69,86 +52,6 @@ export function getAllContent(offset, limit, reset) {
 		});
 	}
 }
-
-function handleContent(payload) {
-	return {
-		type: HANDLE_GET_CONTENT,
-		payload
-	};
-}
-function errorGetContent(id, err) {
-	return {
-		type: ERROR_GET_CONTENT,
-		id,
-		err
-	};
-}
-
-function handleCreateContent(payload) {
-	return {
-		type: HANDLE_CREATE_CONTENT,
-		payload
-	};
-}
-function errorCreateContent(content, err) {
-	return {
-		type: ERROR_CREATE_CONTENT,
-		content,
-		err
-	};
-}
-export function createContent(body) {
-	return dispatch => {
-		return fetch(CONTENT_URL, {
-			method: "POST",
-			body: JSON.stringify(body)
-		}).then((res) => {
-			return res.json();
-		}).then((json) => {
-			if (json.error || !json.success) {
-				dispatch(errorCreateContent(body, json.message))
-				return;
-			}
-
-			dispatch(handleCreateContent(json))
-		}).catch((err) => {
-			dispatch(errorCreateContent(body, err))
-		});
-	}
-}
-
-function handleDeleteContent(payload) {
-	return {
-		type: HANDLE_DELETE_CONTENT,
-		payload
-	};
-}
-function errorDeleteContent(id, err) {
-	return {
-		type: ERROR_DELETE_CONTENT,
-		id,
-		err
-	};
-}
-export function deleteContent(id) {
-	return dispatch => {
-		return fetch(CONTENT_URL+"/"+id, {
-			method: "DELETE"
-		}).then((res) => {
-			return res.json();
-		}).then((json) => {
-			if (json.error || !json.success) {
-				dispatch(errorDeleteTrigger(id, json.message))
-				return;
-			}
-
-			dispatch(handleDeleteContent(json))
-		}).catch((err) => {
-			dispatch(errorDeleteContent(id, err))
-		});
-	}
-}
-
 function handleGetAllTriggers(payload, limit, reset) {
 	return {
 		type: HANDLE_GET_ALL_TRIGGERS,
@@ -183,19 +86,68 @@ export function getAllTriggers(offset, limit, reset) {
 		});
 	}
 }
-
-function handleCreateTrigger(payload) {
+function timeout() {
 	return {
-		type: HANDLE_CREATE_TRIGGER,
+		type: TIMEOUT
+	};
+}
+function handle(payload) {
+	return {
+		type: HANDLE,
 		payload
 	};
 }
-function errorCreateTrigger(body, err) {
+function error(id, err) {
 	return {
-		type: ERROR_CREATE_TRIGGER,
-		body,
+		type: ERROR,
+		id,
 		err
 	};
+}
+
+export function createContent(body) {
+	return dispatch => {
+		setTimeout(() => {
+			dispatch(timeout())
+		}, TIMEOUT_MS);
+		return fetch(CONTENT_URL, {
+			method: "POST",
+			body: JSON.stringify(body)
+		}).then((res) => {
+			return res.json();
+		}).then((json) => {
+			if (json.error || !json.success) {
+				dispatch(error(body, json.message))
+				return;
+			}
+
+			dispatch(handle(json));
+		}).catch((err) => {
+			dispatch(error(body, err));
+		});
+	}
+}
+
+export function deleteContent(id) {
+	return dispatch => {
+		setTimeout(() => {
+			dispatch(timeout())
+		}, TIMEOUT_MS);
+		return fetch(CONTENT_URL+"/"+id, {
+			method: "DELETE"
+		}).then((res) => {
+			return res.json();
+		}).then((json) => {
+			if (json.error || !json.success) {
+				dispatch(error(id, json.message))
+				return;
+			}
+
+			dispatch(handle(json))
+		}).catch((err) => {
+			dispatch(error(id, err))
+		});
+	}
 }
 export function createTrigger(body) {
 	return dispatch => {
@@ -207,32 +159,22 @@ export function createTrigger(body) {
 			return res.json();
 		}).then((json) => {
 			if (json.error || !json.success) {
-				dispatch(errorCreateTrigger(body, json.message))
+				dispatch(error(body, json.message))
 				return;
 			}
 
-			dispatch(handleCreateTrigger(json))
+			dispatch(handle(json))
 		}).catch((err) => {
-			dispatch(errorCreateTrigger(body, err))
+			dispatch(error(body, err))
 		});
 	}
 }
 
-function handleDeleteTrigger(payload) {
-	return {
-		type: HANDLE_DELETE_TRIGGER,
-		payload
-	};
-}
-function errorDeleteTrigger(id, err) {
-	return {
-		type: ERROR_DELETE_TRIGGER,
-		id,
-		err
-	};
-}
 export function deleteTrigger(id) {
 	return dispatch => {
+		setTimeout(() => {
+			dispatch(timeout());
+		}, TIMEOUT_MS);
 		return fetch(TRIGGER_URL+"/" + id, {
 			method: "DELETE"
 		}).then((res) => {
@@ -240,13 +182,13 @@ export function deleteTrigger(id) {
 		}).then((json) => {
 			console.log(json);
 			if (json.error || !json.success) {
-				dispatch(errorDeleteTrigger(id, json.message))
+				dispatch(error(id, json.message))
 				return;
 			}
 
-			dispatch(handleDeleteTrigger(json))
+			dispatch(handle(json))
 		}).catch((err) => {
-			dispatch(errorDeleteTrigger(id, err))
+			dispatch(error(id, err))
 		});
 	}
 }

--- a/src/actions/userActions.js
+++ b/src/actions/userActions.js
@@ -64,6 +64,11 @@ export function authenticateUser(userCreds) {
         }).then((response) => {
             return response.json();
         }).then((json) => {
+            console.log(json);
+            if (!json.success) {
+                dispatch(errorAuthenticatingUser(userCreds, json.message))
+                return;
+            }
             dispatch(receiveAuthenticatedUser(json))
         }).catch((err) => {
             dispatch(errorAuthenticatingUser(userCreds, err));

--- a/src/components/LoginContainer.js
+++ b/src/components/LoginContainer.js
@@ -35,7 +35,8 @@ function mapStateToProps(state) {
     return {
         user: state.userReducer.user,
         isFetching: state.userReducer.isFetching,
-        didAuthenticate: state.userReducer.didAuthenticate
+        didAuthenticate: state.userReducer.didAuthenticate,
+        error: state.userReducer.error
     };
 }
 

--- a/src/components/dashboard/bloodlines/MessageContent.js
+++ b/src/components/dashboard/bloodlines/MessageContent.js
@@ -69,7 +69,7 @@ class MessageContent extends Component {
 								(
 									<div>
 										<div className={toggleClass} onClick={this.toggleAddTrigger.bind(this)}>[-] Trigger</div>
-										<TriggerInput content={item} />
+										<TriggerInput create={this.props.createTrigger} content={item} {...this.props.modify}/>
 									</div>
 								)
 							}

--- a/src/components/dashboard/bloodlines/MessageContentContainer.js
+++ b/src/components/dashboard/bloodlines/MessageContentContainer.js
@@ -39,16 +39,16 @@ class MessageContentContainer extends Component {
 
 	update(reset) {
 		const { dispatch } = this.props;
-		let offset = this.props.getAll.cursor;
+		let offset = this.props.items.cursor;
 		if (reset) {
 			offset = 0;
 		}
 
-		dispatch(getAllContent(offset, 20, reset)).then(this.nextPage.bind(this));
+		dispatch(getAllContent(offset, 20)).then(this.nextPage.bind(this));
 	}
 
 	nextPage() {
-		if (this.props.getAll.next && !this.props.getAll.fetching) {
+		if (this.props.items.next && !this.props.items.fetching) {
 			this.update();
 		}
 	}
@@ -61,7 +61,7 @@ class MessageContentContainer extends Component {
 				<ErrorMessage error={this.props.modify.error} />
 				<SuccessMessage success={this.props.modify.success} message={"Success"} />
 				<MessageContentInput addContent={this.create.bind(this)} {...this.props.modify} />
-				<MessageContentList createTrigger={this.createTrigger.bind(this)} deleteContent={this.delete.bind(this)} {...this.props.getAll} modify={this.props.modify}/>
+				<MessageContentList createTrigger={this.createTrigger.bind(this)} deleteContent={this.delete.bind(this)} {...this.props.items} modify={this.props.modify}/>
 			</div>
 		)
 	}
@@ -69,19 +69,8 @@ class MessageContentContainer extends Component {
 
 function mapStateToProps(state) {
 	return {
-		getAll: {
-			items: state.getAllContent.items,
-			ids: state.getAllContent.ids,
-			fetching: state.getAllContent.fetching,
-			error: state.getAllContent.error,
-			cursor: state.getAllContent.cursor,
-			next: state.getAllContent.next
-		},
-		modify: {
-			fetching: state.modify.fetching,
-			error: state.modify.error,
-			success: state.modify.success
-		}
+		items: state.contents,
+		modify: state.modify
 	};
 }
 

--- a/src/components/dashboard/bloodlines/MessageContentContainer.js
+++ b/src/components/dashboard/bloodlines/MessageContentContainer.js
@@ -1,9 +1,11 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
-import { getAllContent, createContent, deleteContent } from '../../../actions/bloodlinesActions';
+import { getAllContent, createContent, deleteContent, createTrigger } from '../../../actions/bloodlinesActions';
 import MessageContentList from './MessageContentList';
 import MessageContentInput from './MessageContentInput';
+import ErrorMessage from '../../ErrorMessage';
+import SuccessMessage from '../../SuccessMessage';
 
 class MessageContentContainer extends Component {
 	componentDidMount() {
@@ -16,14 +18,16 @@ class MessageContentContainer extends Component {
 		dispatch(createContent(data)).then(this.refresh.bind(this));
 	}
 
-	refresh() {
-		if (this.props.create.success && !this.props.create.fetching) {
-			this.update();
-			return;
-		}
+	createTrigger(data) {
+		const {dispatch} = this.props;
 
-		if (this.props.delete.success && !this.props.delete.fetching) {
+		dispatch(createTrigger(data)).then();
+	}
+
+	refresh() {
+		if (this.props.modify.success && !this.props.modify.fetching) {
 			this.update(true);
+			return;
 		}
 	}
 
@@ -54,8 +58,10 @@ class MessageContentContainer extends Component {
 
 		return (
 			<div>
-				<MessageContentInput addContent={this.create.bind(this)} {...this.props.create} />
-				<MessageContentList deleteContent={this.delete.bind(this)} {...this.props.getAll} />
+				<ErrorMessage error={this.props.modify.error} />
+				<SuccessMessage success={this.props.modify.success} message={"Success"} />
+				<MessageContentInput addContent={this.create.bind(this)} {...this.props.modify} />
+				<MessageContentList createTrigger={this.createTrigger.bind(this)} deleteContent={this.delete.bind(this)} {...this.props.getAll} modify={this.props.modify}/>
 			</div>
 		)
 	}
@@ -71,15 +77,10 @@ function mapStateToProps(state) {
 			cursor: state.getAllContent.cursor,
 			next: state.getAllContent.next
 		},
-		create: {
-			fetching: state.createContent.fetching,
-			error: state.createContent.error,
-			success: state.createContent.success
-		},
-		delete: {
-			fetching: state.deleteContent.fetching,
-			error: state.deleteContent.error,
-			success: state.deleteContent.success
+		modify: {
+			fetching: state.modify.fetching,
+			error: state.modify.error,
+			success: state.modify.success
 		}
 	};
 }

--- a/src/components/dashboard/bloodlines/MessageContentInput.js
+++ b/src/components/dashboard/bloodlines/MessageContentInput.js
@@ -1,8 +1,5 @@
 import React, { Component } from 'react';
 
-import ErrorMessage from '../../ErrorMessage';
-import SuccessMessage from '../../SuccessMessage';
-
 class MessageContentInput extends Component {
 
 	handleSubmit(event){
@@ -19,6 +16,10 @@ class MessageContentInput extends Component {
 	}
 
 	refresh() {
+		if (!this.refs.subject) {
+			return;
+		}
+
 		this.refs.subject.value = "";
 		this.refs.text.value = "";
 		this.refs.parameters.value = "";
@@ -32,7 +33,6 @@ class MessageContentInput extends Component {
 		if (!this.props.fetching && this.props.success) {
 			this.refresh();
 		}
-
 		return (
 			<div className="fl w-40">
 				<form onSubmit={this.handleSubmit.bind(this)} className="pa4 black-80">
@@ -55,8 +55,6 @@ class MessageContentInput extends Component {
 						</div>
 					</div>
 				</form>
-				<ErrorMessage error={this.props.error} />
-				<SuccessMessage success={this.props.success} message={"Successfully created Content"} />
 			</div>
 		)
 	}

--- a/src/components/dashboard/bloodlines/MessageContentInput.js
+++ b/src/components/dashboard/bloodlines/MessageContentInput.js
@@ -12,7 +12,7 @@ class MessageContentInput extends Component {
 			subject: this.refs.subject.value,
 			text: this.refs.text.value,
 			parameters: this.refs.parameters.value.split(","),
-			type: this.refs.type.value
+			contentType: this.refs.type.value
 		};
 
 		this.props.addContent(data);

--- a/src/components/dashboard/bloodlines/MessageContentList.js
+++ b/src/components/dashboard/bloodlines/MessageContentList.js
@@ -10,7 +10,8 @@ class MessageContentList extends Component {
 			<div className="fl w-60 pa4 pa4-ns">
 				<ErrorMessage error={this.props.error} />
 				{this.props.items && this.props.ids.map((key) =>
-					<MessageContent deleteContent={this.props.deleteContent} key={key} item={this.props.items[key]} />
+					<MessageContent deleteContent={this.props.deleteContent} createTrigger={this.props.createTrigger}
+						key={key} item={this.props.items[key]} modify={this.props.modify}/>
 				)}
 				{(!this.props.fetching && this.props.items.length === 0) && (
 					<p>No Content</p>
@@ -21,8 +22,6 @@ class MessageContentList extends Component {
 			</div>
 		)
 	}
-
 }
-
 
 export default MessageContentList;

--- a/src/components/dashboard/bloodlines/TriggerContainer.js
+++ b/src/components/dashboard/bloodlines/TriggerContainer.js
@@ -27,8 +27,7 @@ class TriggerContainer extends Component {
 	}
 
 	refresh() {
-		console.log(this.props.delete);
-		if (this.props.delete.success && !this.props.delete.fetching) {
+		if (this.props.modify.success && !this.props.modify.fetching) {
 			this.update(true);
 		}
 	}
@@ -43,8 +42,8 @@ class TriggerContainer extends Component {
 
 		return (
 			<div>
-				<SuccessMessage success={this.props.delete.success} message={"Deleted Trigger."} />
-				<TriggerList delete={this.delete.bind(this)} {...this.props.getAll} />
+				<SuccessMessage success={this.props.modify.success} message={"Deleted Trigger."} />
+				<TriggerList delete={this.delete.bind(this)} {...this.props.getAll}/>
 			</div>
 		);
 	}
@@ -60,7 +59,7 @@ function mapStateToProps(state) {
 			cursor: state.getAllTriggers.cursor,
 			next: state.getAllTriggers.next
 		},
-		delete: state.deleteTrigger
+		modify: state.modify
 	};
 }
 

--- a/src/components/dashboard/bloodlines/TriggerContainer.js
+++ b/src/components/dashboard/bloodlines/TriggerContainer.js
@@ -12,16 +12,16 @@ class TriggerContainer extends Component {
 
 	update(reset) {
 		const { dispatch } = this.props;
-		let offset = this.props.getAll.cursor;
-		if (reset) {
+		let offset = this.props.items.cursor;
+		if (reset){
 			offset = 0;
 		}
 
-		dispatch(getAllTriggers(offset, 20, reset)).then(this.nextPage.bind(this));
+		dispatch(getAllTriggers(offset, 20)).then(this.nextPage.bind(this));
 	}
 
 	nextPage() {
-		if (this.props.getAll.next && !this.props.getAll.fcreateContentetching) {
+		if (this.props.items.next && !this.props.items.fetching) {
 			this.update();
 		}
 	}
@@ -43,7 +43,7 @@ class TriggerContainer extends Component {
 		return (
 			<div>
 				<SuccessMessage success={this.props.modify.success} message={"Deleted Trigger."} />
-				<TriggerList delete={this.delete.bind(this)} {...this.props.getAll}/>
+				<TriggerList delete={this.delete.bind(this)} {...this.props.items}/>
 			</div>
 		);
 	}
@@ -51,14 +51,7 @@ class TriggerContainer extends Component {
 
 function mapStateToProps(state) {
 	return {
-		getAll: {
-			items: state.getAllTriggers.items,
-			ids: state.getAllTriggers.ids,
-			fetching: state.getAllTriggers.fetching,
-			error: state.getAllTriggers.error,
-			cursor: state.getAllTriggers.cursor,
-			next: state.getAllTriggers.next
-		},
+		items: state.triggers,
 		modify: state.modify
 	};
 }

--- a/src/components/dashboard/bloodlines/TriggerInput.js
+++ b/src/components/dashboard/bloodlines/TriggerInput.js
@@ -1,9 +1,4 @@
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
-
-import ErrorMessage from '../../ErrorMessage';
-import SuccessMessage from '../../SuccessMessage';
-import { createTrigger } from '../../../actions/bloodlinesActions';
 
 class TriggerInput extends Component {
 
@@ -25,20 +20,12 @@ class TriggerInput extends Component {
 			tkey: this.refs.key.value,
 			values: values
 		};
-		console.log(data);
-
-		this.create(data);
-	}
-
-	create(data) {
-		const {dispatch} = this.props;
-
-		dispatch(createTrigger(data)).then(this.refresh.bind(this));
+		this.props.create(data);
 	}
 
 	refresh() {
-		if (this.props.fetching || !this.props.success) {
-			return;
+		if (!this.refs.key){
+			return
 		}
 
 		this.refs.key.value = "";
@@ -77,8 +64,6 @@ class TriggerInput extends Component {
 						<div className="fr pa3 pa3-ns">
 							<input className="self-center b ph3 pv2 input-reset ba b--black bg-white grow pointer f6 dib" type="submit" value="Submit"/>
 						</div>
-						<ErrorMessage error={this.props.error} />
-						<SuccessMessage success={this.props.success} message={"Successfully created trigger"} />
 					</div>
 				</form>
 			</div>
@@ -86,8 +71,4 @@ class TriggerInput extends Component {
 	}
 }
 
-function mapStateToProps(state) {
-	return state.createTrigger;
-}
-
-export default connect(mapStateToProps)(TriggerInput);
+export default TriggerInput;

--- a/src/components/dashboard/bloodlines/TriggerList.js
+++ b/src/components/dashboard/bloodlines/TriggerList.js
@@ -24,5 +24,4 @@ class TriggerList extends Component {
 
 }
 
-
 export default TriggerList;

--- a/src/reducers/bloodlinesReducer.js
+++ b/src/reducers/bloodlinesReducer.js
@@ -1,11 +1,9 @@
 import {
-	//GET_ALL_CONTENT,
-	HANDLE_GET_ALL_CONTENT,
-	ERROR_GET_ALL_CONTENT,
+	HANDLE_PAGED,
+	ERROR_PAGED,
 
-	//GET_ALL_TRIGGERS,
-	HANDLE_GET_ALL_TRIGGERS,
-	ERROR_GET_ALL_TRIGGERS,
+	TRIGGERS,
+	CONTENTS,
 
 	REQUEST,
 	HANDLE,
@@ -13,7 +11,7 @@ import {
 	TIMEOUT
 } from '../actions/bloodlinesActions'
 
-export function getAllContent(state = {
+export function triggers(state = {
 	fetching: false,
 	cursor: 0,
 	next: false,
@@ -21,9 +19,30 @@ export function getAllContent(state = {
 	ids: [],
 	error: null,
 }, action) {
+	if (action.itemType !== TRIGGERS) {
+		return state;
+	}
+	return handlePagedAction(action, state);
+}
+
+export function contents(state = {
+	fetching: false,
+	cursor: 0,
+	next: false,
+	items: {},
+	ids: [],
+	error: null,
+}, action) {
+	if (action.itemType !== CONTENTS) {
+		return state;
+	}
+	return handlePagedAction(action, state);
+}
+
+function handlePagedAction(action, state) {
 	switch (action.type) {
-	case HANDLE_GET_ALL_CONTENT:
-		if (action.reset) {
+	case HANDLE_PAGED:
+		if (action.offset === 0) {
 			state.items = {};
 		}
 		const length = Object.keys(state.items).length;
@@ -48,7 +67,7 @@ export function getAllContent(state = {
 			cursor: cursor,
 			error:null
 		});
-	case ERROR_GET_ALL_CONTENT:
+	case ERROR_PAGED:
 		return Object.assign({}, state, {
 			fetching: false,
 			next: false,
@@ -64,7 +83,6 @@ export function modify(state = {
 	error: null,
 	success: false
 }, action) {
-	console.log(action);
 	return handleModifyAction(action, state);
 }
 
@@ -91,52 +109,6 @@ function handleModifyAction(action, state) {
 			fetching: false,
 			error: null,
 			success: false
-		});
-	default:
-		return state;
-	}
-}
-
-export function getAllTriggers(state = {
-	fetching: false,
-	cursor: 0,
-	next: false,
-	items: {},
-	ids: [],
-	error: null,
-}, action) {
-	switch (action.type) {
-	case HANDLE_GET_ALL_TRIGGERS:
-		if (action.reset) {
-			state.items = {};
-		}
-		const length = Object.keys(state.items).length;
-		let _triggers = state.items;
-		for (let trigger of action.payload.data) {
-			_triggers = {
-				..._triggers,
-				[trigger.id]: trigger
-			};
-		}
-
-		const keys = Object.keys(_triggers);
-		const cursor = keys.length;
-		const hasNew = length < cursor;
-		const isFull = cursor - length >= action.limit;
-
-		return Object.assign({}, state, {
-			fetching: false,
-			next: hasNew && isFull,
-			items: _triggers,
-			ids: keys,
-			cursor: cursor,
-			error:null
-		});
-	case ERROR_GET_ALL_TRIGGERS:
-		return Object.assign({}, state, {
-			fetching: false,
-			next: false,
-			error: action.err
 		});
 	default:
 		return state;

--- a/src/reducers/bloodlinesReducer.js
+++ b/src/reducers/bloodlinesReducer.js
@@ -1,33 +1,33 @@
 import {
-	GET_ALL_CONTENT,
+	//GET_ALL_CONTENT,
 	HANDLE_GET_ALL_CONTENT,
 	ERROR_GET_ALL_CONTENT,
 
-	GET_CONTENT,
-	HANDLE_GET_CONTENT,
-	ERROR_GET_CONTENT,
+	// GET_CONTENT,
+	//HANDLE_GET_CONTENT,
+	// ERROR_GET_CONTENT,
 
-	CREATE_CONTENT,
+	//CREATE_CONTENT,
 	HANDLE_CREATE_CONTENT,
 	ERROR_CREATE_CONTENT,
 
-	DELETE_CONTENT,
+	//DELETE_CONTENT,
 	HANDLE_DELETE_CONTENT,
 	ERROR_DELETE_CONTENT,
 
-	GET_ALL_TRIGGERS,
+	//GET_ALL_TRIGGERS,
 	HANDLE_GET_ALL_TRIGGERS,
 	ERROR_GET_ALL_TRIGGERS,
 
-	GET_TRIGGER,
-	HANDLE_GET_TRIGGER,
-	ERROR_GET_TRIGGER,
+	// GET_TRIGGER,
+	// HANDLE_GET_TRIGGER,
+	// ERROR_GET_TRIGGER,
 
-	CREATE_TRIGGER,
+	//CREATE_TRIGGER,
 	HANDLE_CREATE_TRIGGER,
 	ERROR_CREATE_TRIGGER,
 
-	DELETE_TRIGGER,
+	//DELETE_TRIGGER,
 	HANDLE_DELETE_TRIGGER,
 	ERROR_DELETE_TRIGGER
 } from '../actions/bloodlinesActions'
@@ -41,11 +41,6 @@ export function getAllContent(state = {
 	error: null,
 }, action) {
 	switch (action.type) {
-	case GET_ALL_CONTENT:
-		return Object.assign({}, state, {
-			fetching: true,
-			next: false
-		});
 	case HANDLE_GET_ALL_CONTENT:
 		if (action.reset) {
 			state.items = {};
@@ -89,10 +84,6 @@ export function createContent(state = {
 	success: false
 }, action) {
 	switch (action.type) {
-	case CREATE_CONTENT:
-		return Object.assign({}, state, {
-			fetching: true
-		});
 	case HANDLE_CREATE_CONTENT:
 		return Object.assign({}, state, {
 			fetching: false,
@@ -116,10 +107,6 @@ export function deleteContent(state = {
 	success: false
 }, action) {
 	switch (action.type) {
-	case DELETE_CONTENT:
-		return Object.assign({}, state, {
-			fetching: true
-		});
 	case HANDLE_DELETE_CONTENT:
 		return Object.assign({}, state, {
 			fetching: false,
@@ -146,11 +133,6 @@ export function getAllTriggers(state = {
 	error: null,
 }, action) {
 	switch (action.type) {
-	case GET_ALL_TRIGGERS:
-		return Object.assign({}, state, {
-			fetching: true,
-			next: false
-		});
 	case HANDLE_GET_ALL_TRIGGERS:
 		if (action.reset) {
 			state.items = {};
@@ -194,10 +176,6 @@ export function deleteTrigger(state = {
 	success: false
 }, action) {
 	switch (action.type) {
-	case DELETE_TRIGGER:
-		return Object.assign({}, state, {
-			fetching: true
-		});
 	case HANDLE_DELETE_TRIGGER:
 		console.log(action);
 		return Object.assign({}, state, {
@@ -222,10 +200,6 @@ export function createTrigger(state = {
 	success: false
 }, action) {
 	switch (action.type) {
-	case CREATE_TRIGGER:
-		return Object.assign({}, state, {
-			fetching: true
-		});
 	case HANDLE_CREATE_TRIGGER:
 		return Object.assign({}, state, {
 			fetching: false,

--- a/src/reducers/bloodlinesReducer.js
+++ b/src/reducers/bloodlinesReducer.js
@@ -3,33 +3,14 @@ import {
 	HANDLE_GET_ALL_CONTENT,
 	ERROR_GET_ALL_CONTENT,
 
-	// GET_CONTENT,
-	//HANDLE_GET_CONTENT,
-	// ERROR_GET_CONTENT,
-
-	//CREATE_CONTENT,
-	HANDLE_CREATE_CONTENT,
-	ERROR_CREATE_CONTENT,
-
-	//DELETE_CONTENT,
-	HANDLE_DELETE_CONTENT,
-	ERROR_DELETE_CONTENT,
-
 	//GET_ALL_TRIGGERS,
 	HANDLE_GET_ALL_TRIGGERS,
 	ERROR_GET_ALL_TRIGGERS,
 
-	// GET_TRIGGER,
-	// HANDLE_GET_TRIGGER,
-	// ERROR_GET_TRIGGER,
-
-	//CREATE_TRIGGER,
-	HANDLE_CREATE_TRIGGER,
-	ERROR_CREATE_TRIGGER,
-
-	//DELETE_TRIGGER,
-	HANDLE_DELETE_TRIGGER,
-	ERROR_DELETE_TRIGGER
+	REQUEST,
+	HANDLE,
+	ERROR,
+	TIMEOUT
 } from '../actions/bloodlinesActions'
 
 export function getAllContent(state = {
@@ -78,46 +59,38 @@ export function getAllContent(state = {
 	}
 }
 
-export function createContent(state = {
+export function modify(state = {
 	fetching: false,
 	error: null,
 	success: false
 }, action) {
-	switch (action.type) {
-	case HANDLE_CREATE_CONTENT:
-		return Object.assign({}, state, {
-			fetching: false,
-			success: action.payload.success,
-			error: null
-		});
-	case ERROR_CREATE_CONTENT:
-		return Object.assign({}, state, {
-			fetching: false,
-			success: false,
-			error: action.err
-		});
-	default:
-		return state;
-	}
+	console.log(action);
+	return handleModifyAction(action, state);
 }
 
-export function deleteContent(state = {
-	fetching: false,
-	error: null,
-	success: false
-}, action) {
+function handleModifyAction(action, state) {
 	switch (action.type) {
-	case HANDLE_DELETE_CONTENT:
+	case REQUEST:
+		return Object.assign({}, state, {
+			fetching: true,
+		});
+	case HANDLE:
 		return Object.assign({}, state, {
 			fetching: false,
 			success: action.payload.success,
 			error: null
 		});
-	case ERROR_DELETE_CONTENT:
+	case ERROR:
 		return Object.assign({}, state, {
 			fetching: false,
 			success: action.success,
 			error: action.err
+		});
+	case TIMEOUT:
+		return Object.assign({}, state, {
+			fetching: false,
+			error: null,
+			success: false
 		});
 	default:
 		return state;
@@ -163,53 +136,6 @@ export function getAllTriggers(state = {
 		return Object.assign({}, state, {
 			fetching: false,
 			next: false,
-			error: action.err
-		});
-	default:
-		return state;
-	}
-}
-
-export function deleteTrigger(state = {
-	fetching: false,
-	error: null,
-	success: false
-}, action) {
-	switch (action.type) {
-	case HANDLE_DELETE_TRIGGER:
-		console.log(action);
-		return Object.assign({}, state, {
-			fetching: false,
-			success: action.payload.success,
-			error:null
-		});
-	case ERROR_DELETE_TRIGGER:
-		return Object.assign({}, state, {
-			fetching: false,
-			success: false,
-			error: action.err
-		});
-	default:
-		return state;
-	}
-}
-
-export function createTrigger(state = {
-	fetching: false,
-	error: null,
-	success: false
-}, action) {
-	switch (action.type) {
-	case HANDLE_CREATE_TRIGGER:
-		return Object.assign({}, state, {
-			fetching: false,
-			success: action.payload.success,
-			error: null
-		});
-	case ERROR_CREATE_TRIGGER:
-		return Object.assign({}, state, {
-			fetching: false,
-			success: false,
 			error: action.err
 		});
 	default:

--- a/src/reducers/configureReducers.js
+++ b/src/reducers/configureReducers.js
@@ -1,16 +1,13 @@
 import { combineReducers } from 'redux';
 import { userReducer } from './userReducer';
 import { customerPaymentInfoReducer } from './coinageReducer';
-import {
-	getAllContent, getAllTriggers, modify
-} from './bloodlinesReducer';
+import { triggers, contents, modify } from './bloodlinesReducer';
 
 const rootReducer = combineReducers({
     userReducer,
     customerPaymentInfoReducer,
-    getAllContent,
+    triggers, contents,
     modify,
-    getAllTriggers
 });
 
 export default rootReducer;

--- a/src/reducers/configureReducers.js
+++ b/src/reducers/configureReducers.js
@@ -2,19 +2,15 @@ import { combineReducers } from 'redux';
 import { userReducer } from './userReducer';
 import { customerPaymentInfoReducer } from './coinageReducer';
 import {
-	getAllContent, createContent, deleteContent,
-	getAllTriggers, createTrigger, deleteTrigger
+	getAllContent, getAllTriggers, modify
 } from './bloodlinesReducer';
 
 const rootReducer = combineReducers({
     userReducer,
     customerPaymentInfoReducer,
     getAllContent,
-    createContent,
-    deleteContent,
-    getAllTriggers,
-    createTrigger,
-    deleteTrigger
+    modify,
+    getAllTriggers
 });
 
 export default rootReducer;

--- a/src/reducers/userReducer.js
+++ b/src/reducers/userReducer.js
@@ -23,7 +23,7 @@ export function userReducer(state = {
         case ERROR_AUTHENTICATING_USER:
         case ERROR_CREATING_USER:
             return Object.assign({}, state, {
-                error: true,
+                error: action.err,
                 user: ''
             });
         case LOGOUT:


### PR DESCRIPTION
@jonnykry and I talked earlier about consolidating the reducers and
actions to make less boilerplate for the bloodlines (and dashboard)
code. This is the first attempt to remove unnecessary duplication in
the actions and reducers.

It turns out that all of the functionality of the previous code can
be easily replicated with just three action types rather than three
for each as previous. This means that we reduce code replication
by a significant amount, and consolidate our error handling to just
one or two components rather than scattering it throughout the state.

This also adds a TIMEOUT action to clear the modify state after a
specified number of milliseconds. This is useful for 'refreshing'
state between routes as well as fading error/success messages.

After this refactor, I'm under the suspicion that we could consolidate
many of our actions under these few action types and the 'modify'
reducer. The only code we'd have to write would be the action code
which makes sense since urls and parameter interpretation are similar
from request to request.