### PR TITLE
Refactor bloodlines actions and reducers to a common util files

### DIFF
--- a/src/actions/actionUtil.js
+++ b/src/actions/actionUtil.js
@@ -1,0 +1,96 @@
+import ActionTypes from './actionTypes';
+
+const TIMEOUT_MS = 5000;
+
+function handlePagedRequest(item, url, type, offset, limit) {
+    return dispatch => {
+        return fetch(getAllUrl(url, offset, limit), {
+            method: type
+        }).then(res => {
+            return res.json();
+        }).then(json => {
+            if (json.error || !json.success) {
+                dispatch(errorPaged(item, offset, limit, json.message));
+                return;
+            }
+
+            dispatch(handlePaged(item, json, offset, limit));
+        }).catch(err => {
+            dispatch(errorPaged(item, offset, limit, err));
+        });
+    };
+}
+function handleRequest(url, type, body) {
+    let raw = '';
+    if (body) {
+        raw = JSON.stringify(body);
+    }
+    return dispatch => {
+        setTimeout(() => {
+            dispatch(timeout());
+        }, TIMEOUT_MS);
+        return fetch(url, {
+            method: type,
+            body: raw
+        }).then(res => {
+            return res.json();
+        }).then(json => {
+            if (json.error || !json.success) {
+                dispatch(error(body, json.message));
+                return;
+            }
+
+            dispatch(handle(json));
+        }).catch(err => {
+            dispatch(error(body, err));
+        });
+    };
+}
+function handlePaged(itemType, payload, offset, limit) {
+    return {
+        type: ActionTypes.HANDLE_PAGED,
+        itemType,
+        payload,
+        offset,
+        limit
+    };
+}
+function errorPaged(itemType, err) {
+    return {
+        type: ActionTypes.ERROR_PAGED,
+        itemType,
+        err
+    };
+}
+function timeout() {
+    return {
+        type: ActionTypes.TIMEOUT
+    };
+}
+function handle(payload) {
+    return {
+        type: ActionTypes.HANDLE,
+        payload
+    };
+}
+function error(id, err) {
+    return {
+        type: ActionTypes.ERROR,
+        id,
+        err
+    };
+}
+
+function getAllUrl(url, offset, limit) {
+    return url + '?offset=' + offset + '&limit=' + limit;
+}
+
+export default({
+    handlePagedRequest,
+    handlePaged,
+    handleRequest,
+    timeout,
+    errorPaged,
+    handle,
+    error
+});

--- a/src/actions/bloodlinesActions.js
+++ b/src/actions/bloodlinesActions.js
@@ -1,124 +1,39 @@
 import ActionTypes from './actionTypes';
+import ActionUtil from './actionUtil';
 
-const TIMEOUT_MS = 5000;
 const BLOODLINES_URL = 'https://bloodlines.expresso.store/api';
 const CONTENT_URL = BLOODLINES_URL + '/content';
 const TRIGGER_URL = BLOODLINES_URL + '/trigger';
 const RECEIPT_URL = BLOODLINES_URL + '/receipt';
 
 export function getAllContent(offset, limit) {
-    return handlePagedRequest(ActionTypes.CONTENTS, getAllUrl(CONTENT_URL, offset, limit), 'GET', offset, limit);
+    return ActionUtil.handlePagedRequest(ActionTypes.CONTENTS, CONTENT_URL, 'GET', offset, limit);
 }
 
 export function getAllTriggers(offset, limit) {
-    return handlePagedRequest(ActionTypes.TRIGGERS, getAllUrl(TRIGGER_URL, offset, limit), 'GET', offset, limit);
+    return ActionUtil.handlePagedRequest(ActionTypes.TRIGGERS, TRIGGER_URL, 'GET', offset, limit);
 }
 
 export function getAllReceipts(offset, limit) {
-    return handlePagedRequest(ActionTypes.RECEIPTS, getAllUrl(RECEIPT_URL, offset, limit), 'GET', offset, limit);
+    return ActionUtil.handlePagedRequest(ActionTypes.RECEIPTS, RECEIPT_URL, 'GET', offset, limit);
 }
 
 export function createContent(body) {
-    return handleRequest(CONTENT_URL, 'POST', body);
+    return ActionUtil.handleRequest(CONTENT_URL, 'POST', body);
 }
 
 export function deleteContent(id) {
-    return handleRequest(CONTENT_URL + '/' + id, 'DELETE');
+    return ActionUtil.handleRequest(CONTENT_URL + '/' + id, 'DELETE');
 }
 
 export function createTrigger(body) {
-    return handleRequest(TRIGGER_URL, 'POST', body);
+    return ActionUtil.handleRequest(TRIGGER_URL, 'POST', body);
 }
 
 export function deleteTrigger(id) {
-    return handleRequest(TRIGGER_URL + '/' + id, 'DELETE');
+    return ActionUtil.handleRequest(TRIGGER_URL + '/' + id, 'DELETE');
 }
 
 export function activateTrigger(id, body) {
-    return handleRequest(TRIGGER_URL + '/' + id + '/activate', 'POST', body);
-}
-
-function getAllUrl(url, offset, limit) {
-    return url + '?offset=' + offset + '&limit=' + limit;
-}
-
-function handlePagedRequest(item, url, type, offset, limit) {
-    return dispatch => {
-        return fetch(url, {
-            method: type
-        }).then(res => {
-            return res.json();
-        }).then(json => {
-            if (json.error || !json.success) {
-                dispatch(errorPaged(item, offset, limit, json.message));
-                return;
-            }
-
-            dispatch(handlePaged(item, json, offset, limit));
-        }).catch(err => {
-            dispatch(errorPaged(item, offset, limit, err));
-        });
-    };
-}
-
-function handleRequest(url, type, body) {
-    let raw = '';
-    if (body) {
-        raw = JSON.stringify(body);
-    }
-    return dispatch => {
-        setTimeout(() => {
-            dispatch(timeout());
-        }, TIMEOUT_MS);
-        return fetch(url, {
-            method: type,
-            body: raw
-        }).then(res => {
-            return res.json();
-        }).then(json => {
-            if (json.error || !json.success) {
-                dispatch(error(body, json.message));
-                return;
-            }
-
-            dispatch(handle(json));
-        }).catch(err => {
-            dispatch(error(body, err));
-        });
-    };
-}
-
-function handlePaged(itemType, payload, offset, limit) {
-    return {
-        type: ActionTypes.HANDLE_PAGED,
-        itemType,
-        payload,
-        offset,
-        limit
-    };
-}
-function errorPaged(itemType, err) {
-    return {
-        type: ActionTypes.ERROR_PAGED,
-        itemType,
-        err
-    };
-}
-function timeout() {
-    return {
-        type: ActionTypes.TIMEOUT
-    };
-}
-function handle(payload) {
-    return {
-        type: ActionTypes.HANDLE,
-        payload
-    };
-}
-function error(id, err) {
-    return {
-        type: ActionTypes.ERROR,
-        id,
-        err
-    };
+    return ActionUtil.handleRequest(TRIGGER_URL + '/' + id + '/activate', 'POST', body);
 }

--- a/src/reducers/bloodlinesReducer.js
+++ b/src/reducers/bloodlinesReducer.js
@@ -1,117 +1,24 @@
 import ActionTypes from '../actions/actionTypes';
+import ReducerUtil from './reducerUtil';
 
-export function triggers(state = getPagedState(), action) {
+export function triggers(state = ReducerUtil.getPagedState(), action) {
     if (action.itemType !== ActionTypes.TRIGGERS) {
         return state;
     }
-    return handlePagedAction(action, state);
+    return ReducerUtil.handlePagedAction(action, state);
 }
 
-export function contents(state = getPagedState(), action) {
+export function contents(state = ReducerUtil.getPagedState(), action) {
     if (action.itemType !== ActionTypes.CONTENTS) {
         return state;
     }
-    return handlePagedAction(action, state);
+    return ReducerUtil.handlePagedAction(action, state);
 }
 
-export function receipts(state = getPagedState(), action) {
+export function receipts(state = ReducerUtil.getPagedState(), action) {
     if (action.itemType !== ActionTypes.RECEIPTS) {
         return state;
     }
-    return handlePagedAction(action, state);
+    return ReducerUtil.handlePagedAction(action, state);
 }
 
-function getPagedState() {
-    return {
-        fetching: false,
-        cursor: 0,
-        next: false,
-        items: {},
-        ids: [],
-        error: null
-    };
-}
-
-function handlePagedAction(action, state) {
-    switch (action.type) {
-        case ActionTypes.HANDLE_PAGED: {
-            if (action.offset === 0) {
-                state.items = {};
-            }
-            const length = Object.keys(state.items).length;
-            let _contents = state.items;
-            for (let content of action.payload.data) {
-                _contents = {
-                    ..._contents,
-                    [content.id]: content
-                };
-            }
-
-            const keys = Object.keys(_contents);
-            const cursor = keys.length;
-            const hasNew = length < cursor;
-            const isFull = cursor - length >= action.limit;
-
-            return Object.assign({}, state, {
-                fetching: false,
-                next: hasNew && isFull,
-                items: _contents,
-                ids: keys,
-                cursor: cursor,
-                error: null
-            });
-        }
-        case ActionTypes.ERROR_PAGED: {
-            return Object.assign({}, state, {
-                fetching: false,
-                next: false,
-                error: action.err
-            });
-        }
-        default: {
-            return state;
-        }
-    }
-}
-
-export function modify(state = {
-    fetching: false,
-    error: null,
-    success: false
-}, action) {
-    return handleModifyAction(action, state);
-}
-
-function handleModifyAction(action, state) {
-    switch (action.type) {
-        case ActionTypes.REQUEST: {
-            return Object.assign({}, state, {
-                fetching: true
-            });
-        }
-        case ActionTypes.HANDLE: {
-            return Object.assign({}, state, {
-                fetching: false,
-                success: action.payload.success,
-                error: null
-            });
-        }
-        case ActionTypes.ERROR: {
-            return Object.assign({}, state, {
-                fetching: false,
-                success: action.success,
-                error: action.err
-            });
-        }
-        case ActionTypes.TIMEOUT: {
-            return Object.assign({}, state, {
-                fetching: false,
-                error: null,
-                success: false
-            });
-        }
-        default: {
-            return state;
-        }
-    }
-}

--- a/src/reducers/configureReducers.js
+++ b/src/reducers/configureReducers.js
@@ -1,10 +1,11 @@
-import { combineReducers } from 'redux';
+import {combineReducers} from 'redux';
 
-import { warehouseReducer } from './warehouseReducer';
-import { roasterReducer } from './roasterReducer';
-import { userReducer } from './userReducer';
-import { customerPaymentInfoReducer } from './coinageReducer';
-import { triggers, contents, receipts, modify } from './bloodlinesReducer';
+import {warehouseReducer} from './warehouseReducer';
+import {roasterReducer} from './roasterReducer';
+import {userReducer} from './userReducer';
+import {customerPaymentInfoReducer} from './coinageReducer';
+import {triggers, contents, receipts} from './bloodlinesReducer';
+import ReducerUtil from './reducerUtil';
 
 const rootReducer = combineReducers({
     roasterReducer,
@@ -14,7 +15,7 @@ const rootReducer = combineReducers({
     triggers,
     contents,
     receipts,
-    modify
+    modify: ReducerUtil.modify
 });
 
 export default rootReducer;

--- a/src/reducers/reducerUtil.js
+++ b/src/reducers/reducerUtil.js
@@ -1,0 +1,103 @@
+import ActionTypes from '../actions/actionTypes';
+
+function getPagedState() {
+    return {
+        fetching: false,
+        cursor: 0,
+        next: false,
+        items: {},
+        ids: [],
+        error: null
+    };
+}
+
+function handlePagedAction(action, state) {
+    switch (action.type) {
+        case ActionTypes.HANDLE_PAGED: {
+            if (action.offset === 0) {
+                state.items = {};
+            }
+            const length = Object.keys(state.items).length;
+            let _contents = state.items;
+            for (let content of action.payload.data) {
+                _contents = {
+                    ..._contents,
+                    [content.id]: content
+                };
+            }
+
+            const keys = Object.keys(_contents);
+            const cursor = keys.length;
+            const hasNew = length < cursor;
+            const isFull = cursor - length >= action.limit;
+
+            return Object.assign({}, state, {
+                fetching: false,
+                next: hasNew && isFull,
+                items: _contents,
+                ids: keys,
+                cursor: cursor,
+                error: null
+            });
+        }
+        case ActionTypes.ERROR_PAGED: {
+            return Object.assign({}, state, {
+                fetching: false,
+                next: false,
+                error: action.err
+            });
+        }
+        default: {
+            return state;
+        }
+    }
+}
+
+function modify(state = {
+    fetching: false,
+    error: null,
+    success: false
+}, action) {
+    return handleModifyAction(action, state);
+}
+
+function handleModifyAction(action, state) {
+    switch (action.type) {
+        case ActionTypes.REQUEST: {
+            return Object.assign({}, state, {
+                fetching: true
+            });
+        }
+        case ActionTypes.HANDLE: {
+            return Object.assign({}, state, {
+                fetching: false,
+                success: action.payload.success,
+                error: null
+            });
+        }
+        case ActionTypes.ERROR: {
+            return Object.assign({}, state, {
+                fetching: false,
+                success: action.success,
+                error: action.err
+            });
+        }
+        case ActionTypes.TIMEOUT: {
+            return Object.assign({}, state, {
+                fetching: false,
+                error: null,
+                success: false
+            });
+        }
+        default: {
+            return state;
+        }
+    }
+}
+
+export default({
+    getPagedState,
+    handlePagedAction,
+    handleModifyAction,
+    modify
+});


### PR DESCRIPTION
bloodlinesActions -> actionUtils
bloodlinesReducers -> reducerUtils

I think this should be good, the only question I have is what the best way to export everything is? If everything is in one object, then I end up having to use `this` for some of the calls which doesn't work for the async requests, so I just declared the functions and returned them in a bundled object. 