### PR TITLE
Add Password Reset Pages

### DIFF
--- a/src/actions/userActions.js
+++ b/src/actions/userActions.js
@@ -2,8 +2,10 @@ import ActionTypes from './actionTypes';
 import ActionUtil from './actionUtil';
 import {getRoaster} from './roasterActions';
 
-const AUTHENTICATE_USER_URL = 'https://towncenter.expresso.store/api/auth/login';
-const USER_URL = 'https://towncenter.expresso.store/api/user';
+const BASE_URL = 'https://towncenter.expresso.store/api/';
+const AUTHENTICATE_USER_URL = BASE_URL + 'auth/login';
+const USER_URL = BASE_URL + 'user';
+const RESET_URL = BASE_URL + 'reset';
 
 export function logout() {
     localStorage.removeItem('token');
@@ -119,6 +121,14 @@ export function updateUserInfo(userInfo, userId) {
             dispatch(ActionUtil.error(500, err.message));
         });
     };
+}
+
+export function requestToken(email) {
+    return ActionUtil.handleRequest(RESET_URL + '?email=' + email, 'POST', {});
+}
+
+export function resetPassword(token, passHash) {
+    return ActionUtil.handleRequest(RESET_URL + '/' + token, 'POST', {passHash});
 }
 
 function receiveUser(payload) {

--- a/src/actions/userActions.js
+++ b/src/actions/userActions.js
@@ -26,7 +26,6 @@ export function createUser(userInfo) {
                 dispatch(ActionUtil.error(401, 'Forbidden'));
             }
 
-
             const token = response.headers.get('X-Auth');
             localStorage.setItem('token', token);
 

--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -18,6 +18,7 @@ class Login extends Component {
                         <input className={inputClass} type="password" ref="password" placeholder="Password" name="password" id="password" />
                         <div className="mt3"><input className="w-100 pointer ba b--transparent white br3 bg-green pv3" type="submit" value="Log In" /></div>
                         <div className="mt3 light-gray tc f7">Not a user?  Click Here to <Link to="/register" className="f6 link dib dim mr3 mr4-ns" title="Register">Sign up</Link></div>
+                        <div className="mt3 light-gray tc f7"><Link to="/reset" className="f6 link dib dim mr3 mr4-ns" title="Register">Forgot your password?</Link></div>
                         <ErrorMessage error={this.props.error} />
                     </form>
                 </article>

--- a/src/components/LoginContainer.js
+++ b/src/components/LoginContainer.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { authenticateUser } from '../actions/userActions'
+import { authenticateUser } from '../actions/userActions';
 
 import Login from './Login';
 

--- a/src/components/RequestReset.js
+++ b/src/components/RequestReset.js
@@ -1,0 +1,37 @@
+import React, {Component, PropTypes} from 'react';
+import {Link} from 'react-router';
+
+import ErrorMessage from './ErrorMessage';
+import Title from './Title';
+
+class RequestReset extends Component {
+    render() {
+        const inputClass = 'mt3 pa3 input-reset ba b--white w-100 border-box br3';
+        const display = !this.props.modify.success ?
+            <article className="h-100 bg-blue pa4 mw4 mw6-ns center white">
+                <Link to="/" className="pointer tc f1 b i white no-underline"><Title color="white"/></Link>
+                <div className="f2 tc">Request Reset Email</div>
+                <form onSubmit={this.props.onHandleSubmit} className="w-100">
+                    <input className={inputClass} type="email" ref={this.props._email} placeholder="coffee@expresso.store" name="email" id="email"/>
+                    <div className="mt3"><input className="w-100 pointer ba b--transparent white br3 bg-green pv3" type="submit" value="Request"/></div>
+                    <ErrorMessage error={this.props.error}/>
+                </form>
+            </article> : <div className="mt3 light-gray tc f7">You should be receiveing an email soon.</div>;
+
+        return (
+            <div className="bg-blue h-100">
+                {display}
+            </div>
+        );
+    }
+}
+
+RequestReset.propTypes = {
+    onHandleSubmit: PropTypes.func,
+    _email: PropTypes.func,
+    error: PropTypes.string,
+    modify: PropTypes.object
+};
+
+export default RequestReset;
+

--- a/src/components/RequestReset.js
+++ b/src/components/RequestReset.js
@@ -7,20 +7,21 @@ import Title from './Title';
 class RequestReset extends Component {
     render() {
         const inputClass = 'mt3 pa3 input-reset ba b--white w-100 border-box br3';
-        const display = !this.props.modify.success ?
-            <article className="h-100 bg-blue pa4 mw4 mw6-ns center white">
-                <Link to="/" className="pointer tc f1 b i white no-underline"><Title color="white"/></Link>
-                <div className="f2 tc">Request Reset Email</div>
-                <form onSubmit={this.props.onHandleSubmit} className="w-100">
-                    <input className={inputClass} type="email" ref={this.props._email} placeholder="coffee@expresso.store" name="email" id="email"/>
-                    <div className="mt3"><input className="w-100 pointer ba b--transparent white br3 bg-green pv3" type="submit" value="Request"/></div>
-                    <ErrorMessage error={this.props.error}/>
-                </form>
-            </article> : <div className="mt3 light-gray tc f7">You should be receiveing an email soon.</div>;
+        const display = this.props.modify.success ?
+            <div className="mt3 light-gray tc f7">You should be receiveing an email soon.</div> :
+            <form onSubmit={this.props.onHandleSubmit} className="w-100">
+                <input className={inputClass} type="email" ref={this.props._email} placeholder="coffee@expresso.store" name="email" id="email"/>
+                <div className="mt3"><input className="w-100 pointer ba b--transparent white br3 bg-green pv3" type="submit" value="Request"/></div>
+                <ErrorMessage error={this.props.error}/>
+            </form>;
 
         return (
             <div className="bg-blue h-100">
-                {display}
+                <article className="h-100 bg-blue pa4 mw4 mw6-ns center white">
+                    <Link to="/" className="pointer tc f1 b i white no-underline"><Title color="white"/></Link>
+                    <div className="f2 tc">Request Reset Email</div>
+                    {display}
+                </article>
             </div>
         );
     }

--- a/src/components/RequestResetContainer.js
+++ b/src/components/RequestResetContainer.js
@@ -1,0 +1,58 @@
+import React, {Component, PropTypes} from 'react';
+import {connect} from 'react-redux';
+
+import {requestToken} from '../actions/userActions';
+import RequestReset from './RequestReset';
+
+class RequestResetContainer extends Component {
+    constructor(props) {
+        super(props);
+
+        this.handleSubmitBind = this.handleSubmit.bind(this);
+    }
+
+    handleSubmit(event) {
+        event.preventDefault();
+        const {dispatch} = this.props;
+
+        const email = this.email.value;
+
+        dispatch(requestToken(email));
+    }
+
+    _email() {
+        return (i => {
+            this.email = i;
+        });
+    }
+
+    render() {
+        console.log(this.props.modify);
+        return (
+            <div className="h-100">
+                <RequestReset
+                    onHandleSubmit={this.handleSubmitBind}
+                    error={this.props.error}
+                    modify={this.props.modify}
+                    _email={this._email()}
+                    />
+            </div>
+        );
+    }
+}
+
+RequestResetContainer.propTypes = {
+    error: PropTypes.string,
+    modify: PropTypes.object,
+    dispatch: PropTypes.func
+};
+
+function mapStateToProps(state) {
+    return {
+        modify: state.modify,
+        error: state.errors[500]
+    };
+}
+
+export default connect(mapStateToProps)(RequestResetContainer);
+

--- a/src/components/ResetContainer.js
+++ b/src/components/ResetContainer.js
@@ -1,0 +1,78 @@
+import React, {Component, PropTypes} from 'react';
+import {connect} from 'react-redux';
+
+import {resetPassword} from '../actions/userActions';
+import ActionUtil from '../actions/actionUtil';
+import ResetToken from './ResetToken';
+
+class ResetContainer extends Component {
+    constructor(props) {
+        super(props);
+
+        this.handleSubmitBind = this.handleSubmit.bind(this);
+    }
+
+    handleSubmit(event) {
+        event.preventDefault();
+
+        const {dispatch} = this.props;
+
+        const pass = this.pass.value;
+        const confirm = this.confirm.value;
+
+        if (pass !== confirm) {
+            dispatch(ActionUtil.error(500, 'Passwords must match'));
+            return;
+        }
+        dispatch(ActionUtil.error(500, null));
+
+        dispatch(resetPassword(this.props.params.token, pass)).then(() => {
+            if (this.props.modify.success) {
+                this.props.router.replace('/login');
+            } else {
+                dispatch(ActionUtil.error(500, 'Reset failed, please retry.'));
+                this.props.router.replace('/reset');
+            }
+        });
+    }
+
+    _pass() {
+        return (i => {
+            this.pass = i;
+        });
+    }
+
+    _confirm() {
+        return (i => {
+            this.confirm = i;
+        });
+    }
+
+    render() {
+        return (
+            <ResetToken
+                onHandleSubmit={this.handleSubmitBind}
+                error={this.props.error}
+                _pass={this._pass()}
+                _confirm={this._confirm()}
+                />
+        );
+    }
+}
+
+ResetContainer.propTypes = {
+    error: PropTypes.string,
+    modify: PropTypes.object,
+    dispatch: PropTypes.func,
+    router: PropTypes.object,
+    params: PropTypes.object
+};
+
+function mapStateToProps(state) {
+    return {
+        modify: state.modify,
+        error: state.errors[500]
+    };
+}
+
+export default connect(mapStateToProps)(ResetContainer);

--- a/src/components/ResetToken.js
+++ b/src/components/ResetToken.js
@@ -1,0 +1,35 @@
+import React, {Component, PropTypes} from 'react';
+import {Link} from 'react-router';
+
+import ErrorMessage from './ErrorMessage';
+import Title from './Title';
+
+class ResetToken extends Component {
+    render() {
+        const inputClass = 'mt3 pa3 input-reset ba b--white w-100 border-box br3';
+
+        return (
+            <div className="bg-blue h-100">
+                <article className="h-100 bg-blue pa4 mw4 mw6-ns center white">
+                    <Link to="/" className="pointer tc f1 b i white no-underline"><Title color="white"/></Link>
+                    <div className="f2 tc">Reset Password</div>
+                    <form onSubmit={this.props.onHandleSubmit} className="w-100">
+                        <input className={inputClass} type="password" ref={this.props._pass} placeholder="Password" name="password" id="password"/>
+                        <input className={inputClass} type="password" ref={this.props._confirm} placeholder="Confirm Password" name="confirm" id="confim"/>
+                        <div className="mt3"><input className="w-100 pointer ba b--transparent white br3 bg-green pv3" type="submit" value="Request"/></div>
+                        <ErrorMessage error={this.props.error}/>
+                    </form>
+                </article>
+            </div>
+        );
+    }
+}
+
+ResetToken.propTypes = {
+    onHandleSubmit: PropTypes.func,
+    _pass: PropTypes.func,
+    _confirm: PropTypes.func,
+    error: PropTypes.string
+};
+
+export default ResetToken;

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,8 @@ import About from './components/About';
 import LoginContainer from './components/LoginContainer';
 import Logout from './components/Logout';
 import RegisterContainer from './components/RegisterContainer';
+import ResetContainer from './components/ResetContainer';
+import RequestResetContainer from './components/RequestResetContainer';
 import DashboardContainer from './components/dashboard/DashboardContainer';
 import Home from './components/Home';
 import BrowseBeansContainer from './components/dashboard/browse/BrowseBeansContainer';
@@ -71,6 +73,10 @@ ReactDOM.render(
                     <Route path="subscribe/:id" component={Subscribe}/>
                 </Route>
                 <Route path="settings" component={AccountSettings}/>
+            </Route>
+            <Route path="reset">
+                <IndexRoute component={RequestResetContainer}/>
+                <Route path=":token" component={ResetContainer}/>
             </Route>
         </Router>
     </Provider>,


### PR DESCRIPTION
This adds two pages for resetting your password as well as a link on the login page to direct users who have forgotten.

pages are:
1 `/reset`
2 `/reset/:token`

`1` will send a request for a new password reset, showing an affirmative response if it succeeds. The request will send an email to the user with a link to their unique password reset page (denoted by `:token`). Once there, they can reset their password and then be redirected to the login page on success.