### PR TITLE
Make bean item details more responsive and display all the info

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -33,7 +33,7 @@
         <title>Expresso</title>
     </head>
     <body>
-        <div id="root" class="h-100"></div>
+        <div id="root" class="h-100 helvetica"></div>
         <!--
           This HTML file is a template.
           If you open it directly in the browser, you will see an empty page.

--- a/src/components/dashboard/browse/BeanItemDetails.js
+++ b/src/components/dashboard/browse/BeanItemDetails.js
@@ -1,45 +1,65 @@
-import React, { Component, PropTypes } from 'react';
+import React, {Component, PropTypes} from 'react';
 import {Link} from 'react-router';
 import InfiniteList from '../InfiniteList';
+import BackButton from '../BackButton';
 import BeanItemList from './BeanItemList';
 import BeanItemImage from './BeanItemImage';
-import BackButton from '../BackButton';
 
 class BeanItemDetails extends Component {
     render() {
+        const subClass = 'pointer f2 dim br1 ba bw1 tc ph2 mh4 pv3';
+        const subscribe = this.props.bean.inStockBags > 0 && this.props.bean.isActive ?
+            <Link to={'/dashboard/subscribe/' + this.props.params.id} className="no-underline black">
+                <div className={subClass + ' green'}>Subscribe</div>
+            </Link> :
+                <div>
+                    <div className={subClass + ' black-40 black--40'}>Not Available</div>
+                </div>;
+
         return (
             <div>
-                <BackButton />
-                <div className="mw7 center pa4">
-                    <h1 className="tc"> Details For {this.props.bean.name}</h1>
-                    <BeanItemImage src={this.props.bean.pictureURL} alt={this.props.bean.name}/>
-                    <div className="mb2"><strong>Price: </strong>{this.props.bean.consumerPrice}</div>
-                    <div className="mb2"><strong>In Stock: </strong>{this.props.bean.inStockBags}</div>
-                    <div className="mb2"><strong>Weight: </strong>{this.props.bean.ozInBag} oz</div>
-                    {this.props.bean.isDecaf && 
-                        <div>Decaf</div>
-                    }
-                    {this.props.bean.description &&
-                        <div><strong>Description:</strong> {this.props.bean.description}</div>
-                    }  
-                    {this.props.tags &&
-                        <div>
-                            <h3 className="tc">Tags</h3>                  
-                            {
-                                this.props.bean.tags.map(function(tag) {
-                                    return (
-                                        <div>{tag}</div>
-                                    );
-                                })
+                <BackButton/>
+                <div className="mw7 center pa4 w-100">
+                    <div className="dt-m dib">
+                        <div className="dib w-third-l w-50-m w-100 dtc-m v-top">
+                            <h1 className="tc">{this.props.bean.name}</h1>
+                            <div className="mr2 center">
+                                <BeanItemImage src={this.props.bean.pictureURL} alt={this.props.bean.name}/>
+                            </div>
+                        </div>
+                        <div className="pa1 pl2 dib w-two-thirds-l w-50-m w-100 dtc-m v-top">
+                            <div className="mt3 mb2">
+                                <span className="f2">${this.props.bean.consumerPrice}</span>
+                                <span className="f5 fw1 black-60 ttu">&nbsp;per {this.props.bean.ozInBag} oz bag</span>
+                            </div>
+                            {this.props.bean.isDecaf &&
+                                <div className="br1 bg-gold pa2 ma1 dib">Decaf</div>
+                            }
+                            <div className="br1 bg-gold pa2 ma1 dib">{this.props.bean.coffeeType}</div>
+                            {this.props.bean.description &&
+                                <div>
+                                    <p className="b mb1 f4">About {this.props.bean.name}</p>
+                                    <p className="mt1">{this.props.bean.description}</p>
+                                </div>
+                            }
+                            {this.props.bean.tags &&
+                                <div className="pa2">
+                                    <strong>Tags:</strong>
+                                    {
+                                        this.props.bean.tags.map(tag => {
+                                            return (
+                                                <span className="br1 ba ttu f5 b--black-10 bg-black-05 pa2 ma1" key={tag}>{tag}</span>
+                                            );
+                                        })
+                                    }
+                                </div>
                             }
                         </div>
-                    }
+                    </div>
                 </div>
                 <div className="mw7 center mh3 pointer">
                     <div>
-                        <Link to={'/dashboard/subscribe/' + this.props.params.id} className="no-underline black">
-                                <div className="pointer f2 dim br1 ba bw1 tc ph2 mh4 pv3 green">Subscribe</div>
-                        </Link>
+                        {subscribe}
                     </div>
                 </div>
                 <div className="mw7 center mt5">

--- a/src/components/dashboard/subscriptions/Subscribe.js
+++ b/src/components/dashboard/subscriptions/Subscribe.js
@@ -6,7 +6,7 @@ import BeanItemImage from '../browse/BeanItemImage';
 
 class Subscribe extends Component {
     render() {
-        const inputClass = 'input-reset ba b--silver pa3 mv2 db br3 mh3';
+        const inputClass = 'input-reset ba b--silver pa1 mv3 db br3 mh3';
         const btnClass = 'pointer dim br1 ba bw1 ph2 pv3 black b';
         const rowClass = 'mv3';
 
@@ -19,34 +19,49 @@ class Subscribe extends Component {
 
         return (
             <div className="content h-100 min-h-100 overflow-y-auto">
-                <BackButton />
-                <div className="center mw7 pa3 w-100">
-                    <h1 className="tc pb3"> Subscribe to "{this.props.bean.name}"</h1>
-                    <div className="cb center tc pa3" width="50%" height="50%">
-                        <BeanItemImage alt={this.props.bean.name} src={this.props.bean.pictureURL}/>
+                <BackButton/>
+                <div className="center mw7 pa4 w-100">
+                    <div className="w-100">
+                        <h1 className="tc"> Subscribe to {this.props.bean.name}</h1>
                     </div>
-                    <div className={rowClass + ' f3'}><strong>Coffee type:</strong> {this.props.bean.coffeeType}</div>
-                    {this.props.bean.isDecaf ? <div className="mv3 f4">Note:  this is a decaf coffee bean.</div> : ''}
-                    <div className={rowClass + ' f3'}><strong>Bag size:</strong> {this.props.bean.ozInBag} oz.</div>
-                    <div className={rowClass + ' f3'}><strong>Price per Bag:</strong> {'$' + (this.props.bean.consumerPrice || 0).toFixed(2)}</div>
-                    <div className={rowClass + ' f3'}><strong>In Stock:</strong> {this.props.bean.inStockBags} oz.</div>
-                    <div className={rowClass + ' flex'}>
-                        <p className="pv2 b">Number of Bags (Max 10): </p><input className={inputClass + ' w2'} ref={this.props.quantityRef} onChange={this.props.handleQuantity} defaultValue={1}/>
-                        <p className="pv2 b">Frequency: </p>
-                        <div className="w-25 pv3 ph2">
-                            <Select style={{width: '100%'}}
-                                options={options}
-                                simpleValue
-                                clearable={false}
-                                value={this.props.frequency}
-                                placeholder="Frequency"
-                                onChange={this.props.handleFrequency} />
+                    <div className="dt-m dib">
+                        <div className="dib w-third-l w-50-m w-100 dtc-m v-top">
+                            <div className="cb center tc pa3" width="50%" height="50%">
+                                <BeanItemImage alt={this.props.bean.name} src={this.props.bean.pictureURL}/>
+                            </div>
+                        </div>
+                        <div className="dib pa1 pl2 w-two-thirds-l w-50-m w-100 dtc-m v-top">
+                            <div className={rowClass}>
+                                <span className="f2">${this.props.bean.consumerPrice}</span>
+                                <span className="f5 fw1 black-60 ttu">&nbsp;per {this.props.bean.ozInBag} oz bag</span>
+                            </div>
+                            <div className={rowClass + ' w-100'}>
+                            {this.props.bean.isDecaf &&
+                                <div className="br1 bg-gold pa2 ma1 dib">Decaf</div>
+                            }
+                                <div className="br1 bg-gold pa2 ma1 dib">{this.props.bean.coffeeType}</div>
+                            </div>
+                            <div className={rowClass + ' flex'}>
+                                <p className="pv2 b">Bags (Max 10): </p><input className={inputClass + ' w2'} ref={this.props.quantityRef} onChange={this.props.handleQuantity} defaultValue={1}/>
+                            </div>
+                            <div className={rowClass + ' w-100 flex'}>
+                                <p className="pv2 b">Frequency: </p>
+                                <div className="w-50 pv3 ph2">
+                                    <Select style={{width: '100%'}}
+                                        options={options}
+                                        simpleValue
+                                        clearable={false}
+                                        value={this.props.frequency}
+                                        placeholder="Frequency"
+                                        onChange={this.props.handleFrequency}/>
+                                </div>
+                            </div>
                         </div>
                     </div>
-                    <div className={rowClass + ' f3'}>Total Price: <strong>{'$' + (this.props.bean.consumerPrice * (this.props.quantity || 1)).toFixed(2)}
+                    <div className={rowClass + ' dib w-50-l w-100 f3'}>Price: <strong>{'$' + (this.props.bean.consumerPrice * (this.props.quantity || 1)).toFixed(2)}
                         {' ' + (this.props.frequency.charAt(0) + this.props.frequency.substr(1).toLowerCase()) || 'Monthly'}</strong></div>
-                    <div className="mv4 flex">
-                        <div className={btnClass + ' center ph5'} onClick={this.props.handleSubscribe}>
+                    <div className="mv4 dib w-50 center">
+                        <div className={btnClass + ' tc center w-50-l w-100'} onClick={this.props.handleSubscribe}>
                             Subscribe
                         </div>
                     </div>


### PR DESCRIPTION
Looks like this:

![update](https://cloud.githubusercontent.com/assets/5702686/25075272/672b9744-22d6-11e7-84bd-f440bfe9c545.png)
